### PR TITLE
Add CI, fix page-marker drift, and rewrite CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      # Slide markers are speaker-facing only, so drift is invisible in the
+      # rendered deck — check them before the build.
+      - run: bun run check:pages
+
+      - run: bun run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,12 @@ A single-deck RemdX (React + MDX) presentation: 「Claude Codeによる並列開
 ```bash
 bun dev         # dev server on :5173 (npm run dev also works)
 bun run build   # vite build -> dist/
+bun run check:pages  # validate <Note>Page N</Note> markers against slide order
 bun run screenshot   # requires `bun dev` running first (see below)
 bun run deploy  # vercel --prod
 ```
 
-There is no test suite, linter, or typecheck script — TypeScript is not even a declared dependency, and Vite does not typecheck. Verify changes by loading the dev server and paging through the affected slides.
+CI (`.github/workflows/ci.yml`) runs `check:pages` then `build` on pushes to `main` and on every PR. That is the whole safety net: there is no test suite, no linter, and no typecheck — TypeScript is not even a declared dependency, and Vite does not typecheck, so `Components.tsx`/`Themes.tsx` type errors reach production. Verify visual changes by loading the dev server and paging through the affected slides.
 
 `screenshot` runs `screenshot.mjs`, which drives Playwright against `http://localhost:5173` and writes `card.png` **into the repo root**. The OGP/Twitter meta tags in `index.html` point at `/card.png`, which is served from `public/` — so after regenerating, move the file into `public/card.png` or the social card won't change.
 
@@ -48,7 +49,7 @@ The render chain is small but entirely implicit; nothing imports anything the us
   ```
   `transition: none` is used heavily for build-up sequences — several near-identical slides that progressively reveal content, which should feel like one slide.
 - `<Note>` renders `display: none`. It carries both the page number (`<Note>Page 12</Note>`) and free-form Japanese speaker notes; a slide often has two or more `<Note>` blocks.
-- Page markers currently run `1`–`46` in slide order, one per slide, with no gaps. Nothing validates this, so it drifts easily: when adding, removing, or reordering slides, renumber every `<Note>Page N</Note>` from the insertion point onward.
+- Page markers run `1`–`46` in slide order, one per slide. When adding, removing, or reordering slides, renumber every `<Note>Page N</Note>` from the insertion point onward — `bun run check:pages` enforces this in CI and reports offenders as `file:line`.
 - Images live in `public/` and are referenced both as `/name.png` and `./name.png`; both resolve.
 
 ### Layout constraints (`styles.css`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The render chain is small but entirely implicit; nothing imports anything the us
   ```
   `transition: none` is used heavily for build-up sequences — several near-identical slides that progressively reveal content, which should feel like one slide.
 - `<Note>` renders `display: none`. It carries both the page number (`<Note>Page 12</Note>`) and free-form Japanese speaker notes; a slide often has two or more `<Note>` blocks.
-- **Page numbers have drifted** — everything from the "Page 29" slide onward is currently stamped `Page 46`, and there is a duplicate `Page 22`. When adding, removing, or reordering slides, renumber the `<Note>Page N</Note>` markers so numbering stays accurate; fixing existing drift in a range you touch is welcome.
+- Page markers currently run `1`–`46` in slide order, one per slide, with no gaps. Nothing validates this, so it drifts easily: when adding, removing, or reordering slides, renumber every `<Note>Page N</Note>` from the insertion point onward.
 - Images live in `public/` and are referenced both as `/name.png` and `./name.png`; both resolve.
 
 ### Layout constraints (`styles.css`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,57 +4,66 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a React presentation slide deck built with RemdX (React + MDX) using Vite. The project creates interactive slides for a presentation about "The Fall of React Native Bridge" delivered at meguro.es.
+A single-deck RemdX (React + MDX) presentation: 「Claude Codeによる並列開発のすゝめ」, an LT given at Claude Code Meetup about parallel development with git worktree / git bare clone. Slide content and speaker notes are in Japanese. Deployed to Vercel at `claude-code-meetup-lt.vercel.app`.
+
+## Commands
+
+```bash
+bun dev         # dev server on :5173 (npm run dev also works)
+bun run build   # vite build -> dist/
+bun run screenshot   # requires `bun dev` running first (see below)
+bun run deploy  # vercel --prod
+```
+
+There is no test suite, linter, or typecheck script — TypeScript is not even a declared dependency, and Vite does not typecheck. Verify changes by loading the dev server and paging through the affected slides.
+
+`screenshot` runs `screenshot.mjs`, which drives Playwright against `http://localhost:5173` and writes `card.png` **into the repo root**. The OGP/Twitter meta tags in `index.html` point at `/card.png`, which is served from `public/` — so after regenerating, move the file into `public/card.png` or the social card won't change.
 
 ## Architecture
 
-- **Slide Content**: `slides.re.mdx` - Main presentation content written in MDX format
-- **Components**: `Components.tsx` - Custom React components for slide layouts (Center, Heading, MyIcon, etc.)
-- **Themes**: `Themes.tsx` - Presentation theme definitions
-- **Build Tool**: Vite with `@nkzw/vite-plugin-remdx` for MDX processing
-- **Screenshots**: `screenshot.mjs` - Playwright script for generating slide thumbnails
+The render chain is small but entirely implicit; nothing imports anything the usual way:
 
-## Development Commands
+1. `index.html` has an inline module script that imports `@nkzw/remdx/style.css` + `./styles.css` and calls `render(document.getElementById('app'), import('./slides.re.mdx'))`.
+2. `@nkzw/vite-plugin-remdx` (registered in `vite.config.ts`) compiles `slides.re.mdx`.
+3. `slides.re.mdx` starts with two re-exports:
+   ```js
+   export { Components } from "./Components.tsx";
+   export { Themes } from "./Themes.tsx";
+   ```
+   RemdX picks these up, which is why every slide can use `<Row>`, `<Column>`, `<Image>` etc. with **no per-slide imports**. Adding a new slide component means adding a key to the `Components` object in `Components.tsx` — nothing else.
+4. `slides.re.mdx.d.ts` supplies the TS types for the `.re.mdx` import.
 
-```bash
-# Start development server
-bun dev
-# or
-npm run dev
+### Slide syntax in `slides.re.mdx`
 
-# Build for production
-bun run build
-# or
-npm run build
+- `---` on its own line separates slides.
+- An optional metadata block may precede a slide's body, terminated by `--`:
+  ```
+  ---
 
-# Generate slide screenshot
-bun run screenshot
-# or
-npm run screenshot
+  transition: none
 
-# Deploy to Vercel
-bun run deploy
-# or
-npm run deploy
-```
+  --
 
-## Key Dependencies
+  # Slide title
+  ```
+  `transition: none` is used heavily for build-up sequences — several near-identical slides that progressively reveal content, which should feel like one slide.
+- `<Note>` renders `display: none`. It carries both the page number (`<Note>Page 12</Note>`) and free-form Japanese speaker notes; a slide often has two or more `<Note>` blocks.
+- **Page numbers have drifted** — everything from the "Page 29" slide onward is currently stamped `Page 46`, and there is a duplicate `Page 22`. When adding, removing, or reordering slides, renumber the `<Note>Page N</Note>` markers so numbering stays accurate; fixing existing drift in a range you touch is welcome.
+- Images live in `public/` and are referenced both as `/name.png` and `./name.png`; both resolve.
 
-- `@nkzw/remdx` - RemdX library for React + MDX slides (patched version)
-- `@nkzw/vite-plugin-remdx` - Vite plugin for RemdX processing
-- `playwright` - Used for screenshot generation
-- React 18 with TypeScript
+### Layout constraints (`styles.css`)
 
-## Development Notes
+`styles.css` is the fragile part of this repo. It overrides RemdX's own inline styles via `!important` and attribute selectors such as `div[style*="transform: scale"]` and `div[style*="position: relative"][style*="z-index: 0"]`. Consequences:
 
-- The project uses Bun as the package manager (bun.lockb present)
-- TypeScript configuration is strict with noUnusedLocals enabled
-- Custom patch applied to `@nkzw/remdx@0.8.0` (see patches directory)
-- Slide images are stored in the `public/` directory
-- The presentation runs on port 5173 in development mode
+- RemdX's automatic slide **scaling transform is disabled**. Content does not shrink to fit — a slide that overflows the fixed white card (`calc(100vh - 3rem)`, `overflow: hidden`) is silently clipped. This is why `Components.tsx` sizes things in `vh`/fixed px and why images are given explicit `width`/`height`.
+- The page paints a pink→yellow gradient background with a white card on top, forced globally. `Themes.tsx` only swaps the `--background-color`/`--text-color` CSS vars, so the `dark` theme is largely neutralized by these overrides.
+- Any `@nkzw/remdx` upgrade can change the emitted inline styles and break these selectors. Check every slide visually after bumping it.
 
-## Slide Management
+## Dependency notes
 
-- Slides are separated by `---` markers in `slides.re.mdx`
-- Each slide should have a `<Note>Page X</Note>` component indicating its page number
-- **IMPORTANT**: When adding, removing, or reordering slides, always update the page numbers in the `<Note>` components accordingly to maintain accurate slide numbering
+- `patches/@nkzw__remdx@0.8.0.patch` is **stale**: the dependency is at `0.17.0` and `package.json` declares no `patchedDependencies`, so the patch is not applied. Do not treat it as active behavior.
+- Bun is the package manager (`bun.lockb`); npm scripts work too. React 19, Vite 6.
+
+## `docs/ai/`
+
+Japanese background notes on git worktree, git bare clone, and an earlier outline of the talk. These are source material for the slides, not documentation of this codebase.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "slide-static-hermes",
+  "name": "slide-claude-code-lt",
   "version": "0.0.1",
   "type": "module",
   "dependencies": {
@@ -15,11 +15,6 @@
     "playwright": "^1.50.0",
     "vercel": "^44.2.13",
     "vite": "^6.0.7"
-  },
-  "pnpm": {
-    "overrides": {
-      "shiki": "^0.11.0"
-    }
   },
   "scripts": {
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "vite build",
+    "check:pages": "node ./scripts/check-page-numbers.mjs",
     "dev": "vite dev",
     "screenshot": "node ./screenshot.mjs",
     "deploy": "vercel --prod"

--- a/scripts/check-page-numbers.mjs
+++ b/scripts/check-page-numbers.mjs
@@ -1,0 +1,59 @@
+// Verifies that every slide in slides.re.mdx carries exactly one
+// <Note>Page N</Note> marker and that N matches the slide's position.
+// Nothing else enforces this, and the numbering has silently drifted before.
+import { readFileSync } from "node:fs";
+
+const FILE = "slides.re.mdx";
+const lines = readFileSync(FILE, "utf8").split("\n");
+
+// Split into slides on a bare `---`, ignoring separators inside code fences.
+const slides = [[]];
+let inFence = false;
+for (const [index, line] of lines.entries()) {
+  if (line.startsWith("```")) inFence = !inFence;
+  if (!inFence && line.trim() === "---") {
+    slides.push([]);
+    continue;
+  }
+  slides.at(-1).push({ line, number: index + 1 });
+}
+
+const errors = [];
+slides.forEach((slide, index) => {
+  const expected = index + 1;
+  const markers = slide.flatMap(({ line, number }) => {
+    const match = line.match(/<Note>Page (\d+)<\/Note>/);
+    return match ? [{ found: Number(match[1]), number }] : [];
+  });
+
+  if (markers.length === 0) {
+    errors.push(`slide ${expected}: missing <Note>Page ${expected}</Note>`);
+    return;
+  }
+  if (markers.length > 1) {
+    errors.push(
+      `slide ${expected}: ${markers.length} page markers (lines ${markers
+        .map(({ number }) => number)
+        .join(", ")}), expected 1`,
+    );
+    return;
+  }
+
+  const [{ found, number }] = markers;
+  if (found !== expected) {
+    errors.push(
+      `${FILE}:${number}: says "Page ${found}" but this is slide ${expected}`,
+    );
+  }
+});
+
+if (errors.length > 0) {
+  console.error(`Page marker check failed (${slides.length} slides):\n`);
+  for (const error of errors) console.error(`  ${error}`);
+  console.error(
+    `\nRenumber the <Note>Page N</Note> markers so they match slide order.`,
+  );
+  process.exit(1);
+}
+
+console.log(`Page markers OK: ${slides.length} slides, numbered 1-${slides.length}.`);

--- a/slides.re.mdx
+++ b/slides.re.mdx
@@ -366,7 +366,7 @@ transition: none
 git clone --bare <repository-url>
 ```
 
-<Note>Page 22</Note>
+<Note>Page 23</Note>
 
 ---
 
@@ -470,7 +470,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 30</Note>
 
 ---
 
@@ -489,7 +489,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 31</Note>
 
 ---
 
@@ -509,13 +509,13 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 32</Note>
 
 ---
 
 # 作成したスクリプト
 
-<Note>Page 46</Note>
+<Note>Page 33</Note>
 
 ---
 
@@ -531,7 +531,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 34</Note>
 
 ---
 
@@ -548,7 +548,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 35</Note>
 
 ---
 
@@ -566,7 +566,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 36</Note>
 
 ---
 
@@ -585,7 +585,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 37</Note>
 
 ---
 
@@ -596,7 +596,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 38</Note>
 
 ---
 
@@ -612,7 +612,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 39</Note>
 
 ---
 
@@ -629,7 +629,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 40</Note>
 
 ---
 
@@ -647,7 +647,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 41</Note>
 
 ---
 
@@ -666,7 +666,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 42</Note>
 
 ---
 
@@ -689,7 +689,7 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 43</Note>
 <Note>自己紹介スライド</Note>
 
 ---
@@ -704,14 +704,14 @@ transition: none
   </Column>
 </Row>
 
-<Note>Page 46</Note>
+<Note>Page 44</Note>
 <Note>Ad slide</Note>
 
 ---
 
 # Thank You!
 
-<Note>Page 46</Note>
+<Note>Page 45</Note>
 
 ---
 


### PR DESCRIPTION
Three related changes: accurate repo docs, a fix for the drifted speaker-note numbering, and CI so that numbering and the build stay checked from now on.

## Set up CI (`1be7ced`)

The repo had no CI at all, so a slide edit that broke the build or the numbering only surfaced on deploy — or during the talk. `.github/workflows/ci.yml` runs on pushes to `main` and on every PR:

1. `bun install --frozen-lockfile`
2. `bun run check:pages`
3. `bun run build`

`scripts/check-page-numbers.mjs` is new. It splits `slides.re.mdx` on bare `---` (ignoring separators inside code fences) and requires exactly one `<Note>Page N</Note>` per slide, with `N` matching slide order. Failures are reported as `file:line`:

```
slides.re.mdx:369: says "Page 22" but this is slide 23
```

Nothing else is in CI yet: there is no test suite or linter, and a typecheck step needs TypeScript added as a dependency first (see #8).

## Fix page-marker drift (`91bd0f1`)

The markers no longer matched slide order — slide 23 was stamped `Page 22` (duplicating slide 22, so `23` never appeared), and slides 30–46 were all stamped `Page 46`. Renumbered every marker to its actual position, 1–46. 17 lines changed, exactly the wrong ones. Closes item 1 of #8.

Also cleaned up `package.json`:

- renamed `slide-static-hermes` (carried over from the template deck) to `slide-claude-code-lt`
- removed the `pnpm.overrides` pin of shiki to `^0.11.0`. The repo installs with Bun, which does not read `pnpm.overrides`, so the pin never applied — the resolved version is `0.10.1` both before and after removal. Converting it to a Bun-honored field would have *changed* the installed version rather than preserving current behavior, so removal was the behavior-preserving option. Closes item 5 of #8.

## Rewrite CLAUDE.md (`2ae3a38`)

The existing file described a different talk entirely ("The Fall of React Native Bridge" at meguro.es) and stale versions (React 18, remdx 0.8.0 patched). Replaced with the current deck and stack, plus the things that take reading several files to work out:

- the implicit render chain — `index.html` inline script → `vite-plugin-remdx` → the `export { Components } / { Themes }` re-exports that make custom components available with no per-slide imports
- the `--`-terminated per-slide metadata block (`transition: none`), used for progressive-reveal sequences
- that `styles.css` disables RemdX's scale-to-fit transform via `div[style*="transform: scale"]` overrides, so overflowing slides are silently clipped rather than shrunk — the main upgrade risk in the repo
- `bun run screenshot` writes `card.png` to the repo root while the OGP tags serve `public/card.png`, so the file has to be moved
- `patches/@nkzw__remdx@0.8.0.patch` is stale and not applied

## Verification

- `bun install --frozen-lockfile` passes after the `package.json` change and leaves `bun.lockb` untouched — checked first, since that would otherwise turn CI red
- full CI sequence run locally: install → `check:pages` → `build`, all green
- the page check was run against the pre-fix content and reports all 17 offenders; it passes on the current file
- deck rendered from the dev server and slide 12 screenshotted to confirm shiki code highlighting is unchanged after dropping the shiki pin

CI has not run on GitHub Actions yet — this PR is its first execution.

Not addressed here: #9 (`<Note>` nesting block elements inside `<p>`, and the `/favicon.ico` 404), and items 2–4 and 6 of #8.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXXb5ytpQRFuFZqJHzucqH)_