### PR TITLE
Fix invalid paragraph nesting and add a favicon

### DIFF
--- a/Components.tsx
+++ b/Components.tsx
@@ -43,14 +43,16 @@ export const Components = {
       }}
     />
   ),
+  // A <div>, not a <p>: notes hold paragraphs and lists, which are illegal
+  // inside <p> and make React log a nesting error on every load.
   Note: ({ children }: { children: React.ReactNode }) => (
-    <p
+    <div
       style={{
         display: "none",
       }}
     >
       {children}
-    </p>
+    </div>
   ),
   Row: ({ children }: { children: React.ReactNode }) => (
     <div

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Claude Codeによる並列開発のすゝめ</title>
+    <link rel="icon" href="/naturalclar.jpg" />
     <meta
       name="viewport"
       content="width=device-width, user-scalable=no, initial-scale=1, viewport-fit=cover"

--- a/slides.re.mdx
+++ b/slides.re.mdx
@@ -349,9 +349,9 @@ transition: none
   <Column align="center">
     <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
       <GPTImage src="/gpt-git-bear.png" alt="git bare clone"/>
-      <p style={{ margin: 0, fontSize: 12, opacity: 0.4 }}>
+      <div style={{ margin: 0, fontSize: 12, opacity: 0.4 }}>
         *bear ではありません
-      </p>
+      </div>
     </div>
   </Column>
 </Row>


### PR DESCRIPTION
Clears every console error on load. Fixes #9.

## Block elements inside `<p>`

`Note` rendered a paragraph:

```tsx
Note: ({ children }) => <p style={{ display: "none" }}>{children}</p>
```

Multi-line speaker notes compile to `<p>` and `<ul>` children, which are illegal inside `<p>`, so React logged a nesting error on every load. It now renders a `<div>`. This affected the notes on slides 1, 2 and 6.

The same mistake turned out to exist in the slide markup itself. The bare-clone slide wraps its caption in a raw `<p>`, and MDX turns the text inside it into a second `<p>`:

```mdx
<p style={{ margin: 0, fontSize: 12, opacity: 0.4 }}>
  *bear ではありません
</p>
```

Changed to a `<div>` as well. **This one was not in the issue** — it only surfaced once the `Note` errors stopped masking it, so it is worth knowing that the original report was incomplete rather than that the fix went out of scope.

Impact was limited either way: the deck is client-rendered only, so there was no real hydration mismatch, and the notes are `display: none`. But it is invalid HTML, it re-triggers on any new multi-paragraph note, and it would become a genuine hydration error if prerendering were ever added.

## Favicon

`index.html` declared no icon, so the browser's automatic `/favicon.ico` request 404'd. It now points at `public/naturalclar.jpg` — the existing 394×394 square avatar already used in the deck as `MyIcon`, so no new asset was added. Happy to swap in a dedicated icon if you'd rather not use the avatar.

## Verification

Rendered from the dev server and inspected the live DOM:

- **no console errors at all** — three distinct ones before, zero now
- no `<p>` in the DOM contains a block child (was 4: three notes plus the caption)
- `link[rel=icon]` resolves; `curl` on `/favicon.ico` was the original 404 repro
- the bare-clone slide renders unchanged — the caption keeps `font-size: 12px` / `opacity: 0.4` and both caption lines sit where they did before
- `bun run check:pages` and `bun run build` pass locally

Branch was restarted from `main` since #10 is already merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXXb5ytpQRFuFZqJHzucqH)_