### PR TITLE
Publish the deck to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Allow the deploy job to publish to Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Let a running deploy finish rather than cancelling it mid-publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # enablement turns Pages on for the repo if it is not configured yet,
+      # so the first run does not need a manual visit to Settings.
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A single-deck RemdX (React + MDX) presentation: 「Claude Codeによる並列開発のすゝめ」, an LT given at Claude Code Meetup about parallel development with git worktree / git bare clone. Slide content and speaker notes are in Japanese. Deployed to Vercel at `claude-code-meetup-lt.vercel.app`.
+A single-deck RemdX (React + MDX) presentation: 「Claude Codeによる並列開発のすゝめ」, an LT given at Claude Code Meetup about parallel development with git worktree / git bare clone. Slide content and speaker notes are in Japanese.
+
+Deployed to two places from `main`: Vercel at `claude-code-meetup-lt.vercel.app` (still the canonical URL the OGP tags point at) and GitHub Pages at `naturalclar.github.io/slide-claude-code-lt/` via `.github/workflows/deploy-pages.yml`. Pages serves from a sub-path, which is why `vite.config.ts` sets `base: './'` — keep asset references relative or they break there while continuing to work on Vercel.
 
 ## Commands
 
@@ -51,7 +53,7 @@ The render chain is small but entirely implicit; nothing imports anything the us
   `transition: none` is used heavily for build-up sequences — several near-identical slides that progressively reveal content, which should feel like one slide.
 - `<Note>` renders `display: none`. It carries both the page number (`<Note>Page 12</Note>`) and free-form Japanese speaker notes; a slide often has two or more `<Note>` blocks.
 - Page markers run `1`–`46` in slide order, one per slide. When adding, removing, or reordering slides, renumber every `<Note>Page N</Note>` from the insertion point onward — `bun run check:pages` enforces this in CI and reports offenders as `file:line`.
-- Images live in `public/` and are referenced both as `/name.png` and `./name.png`; both resolve.
+- Images live in `public/` and **must be referenced as `./name.png`, never `/name.png`**. These are runtime JSX strings that Vite does not rewrite, so a root-absolute path resolves against the host root and 404s under the GitHub Pages project sub-path. It still works on Vercel, so this breaks on one deploy target only.
 
 ### Layout constraints (`styles.css`)
 

--- a/Components.tsx
+++ b/Components.tsx
@@ -25,7 +25,7 @@ export const Components = {
   ),
   MyIcon: () => (
     <img
-      src="/naturalclar.jpg"
+      src="./naturalclar.jpg"
       style={{
         height: 400,
         width: 400,

--- a/slides.re.mdx
+++ b/slides.re.mdx
@@ -5,7 +5,7 @@ export { Themes } from "./Themes.tsx";
 
 <Row>
   <Column justify="center">
-    <GPTImage src="/gpt-agentic-coding.png" width="500"/>
+    <GPTImage src="./gpt-agentic-coding.png" width="500"/>
   </Column>
   <Column justify="end" align="right">
     <Link href="https://github.com/Naturalclar">Naturalclar</Link>
@@ -130,7 +130,7 @@ transition: none
 
 <Row>
   <Column align="center">
-    <GPTImage src="/gpt-git-branch.png" alt="gpt-git-branch"/>
+    <GPTImage src="./gpt-git-branch.png" alt="gpt-git-branch"/>
   </Column>
 </Row>
 
@@ -193,7 +193,7 @@ transition: none
 
 <Row>
   <Column align="center">
-    <GPTImage src="/gpt-git-worktree.png" alt="git worktree"/>
+    <GPTImage src="./gpt-git-worktree.png" alt="git worktree"/>
   </Column>
 </Row>
 
@@ -348,7 +348,7 @@ transition: none
 <Row>
   <Column align="center">
     <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
-      <GPTImage src="/gpt-git-bear.png" alt="git bare clone"/>
+      <GPTImage src="./gpt-git-bear.png" alt="git bare clone"/>
       <div style={{ margin: 0, fontSize: 12, opacity: 0.4 }}>
         *bear ではありません
       </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,8 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  // Relative, so the same build works at the Vercel root and under the
+  // GitHub Pages project sub-path (/slide-claude-code-lt/).
+  base: './',
   plugins: [remdx(), react()],
 });


### PR DESCRIPTION
Adds `.github/workflows/deploy-pages.yml`, which builds on pushes to `main` and deploys to Pages. It uses `configure-pages` with `enablement: true`, so **you should not need to switch Pages on by hand** — if the token cannot enable it, the first run fails there and Settings → Pages → Source: GitHub Actions fixes it.

Result URL: `https://naturalclar.github.io/slide-claude-code-lt/`

## The deck was not sub-path safe

This is the part worth reviewing. A project repo serves from `/slide-claude-code-lt/`, not a domain root, and the deck had two problems with that:

**1. Build output was rooted at `/`.** `vite.config.ts` now sets `base: './'`, so the emitted script, stylesheet and favicon URLs come out relative. Confirmed in `dist/index.html`:

```html
href="./naturalclar.jpg"
src="./assets/index-BbOPYVac.js"
href="./assets/index-m43d8_Vr.css"
```

**2. Six images were referenced as `/name.png`.** Four slide images plus the avatar in `Components.tsx`. These are **runtime JSX strings, which Vite does not rewrite** — `base` does not help them. They resolve against the host root, so under the sub-path they would have 404'd:

| | before | after |
| --- | --- | --- |
| `slides.re.mdx` | `/gpt-agentic-coding.png`, `/gpt-git-bear.png`, `/gpt-git-branch.png`, `/gpt-git-worktree.png` | `./…` |
| `Components.tsx` | `/naturalclar.jpg` | `./…` |

The other six slide images were already `./`, which is why this was half-broken rather than obviously broken.

One thing I checked before relying on relative paths: paging through the deck only changes the **query string** (`?slideIndex=5&stepIndex=0`), never the path. If RemdX had pushed a path segment, `./name.png` would have started resolving one directory deeper as you advanced. It does not, so relative references stay correct on every slide.

## Verification

Served the real build under `/slide-claude-code-lt/` — the exact shape Pages uses — and paged through all 46 slides:

- **11 images in the DOM, 0 broken** (checked `naturalWidth > 0`, so actually decoded, not merely requested)
- **no HTTP response ≥ 400 and no failed request**
- **no console errors**
- spot-checked the bare-clone slide, whose image was one of the root-absolute ones: renders correctly

`check:pages`, `typecheck` and `build` all pass.

## Vercel is untouched

A relative build works from a domain root too, so the existing Vercel deploy keeps working and **I left the OGP/Twitter tags pointing at `claude-code-meetup-lt.vercel.app`** as the canonical URL. The repo now publishes to both from `main`.

If you would rather Pages become canonical — or retire Vercel — that means repointing those absolute meta URLs and dropping the `deploy` script, which is a separate decision I did not want to make for you. Say which way you want it and I'll follow up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXXb5ytpQRFuFZqJHzucqH)_