### PR TITLE
Point the OGP tags at GitHub Pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A single-deck RemdX (React + MDX) presentation: 「Claude Codeによる並列開発のすゝめ」, an LT given at Claude Code Meetup about parallel development with git worktree / git bare clone. Slide content and speaker notes are in Japanese.
 
-Deployed to two places from `main`: Vercel at `claude-code-meetup-lt.vercel.app` (still the canonical URL the OGP tags point at) and GitHub Pages at `naturalclar.github.io/slide-claude-code-lt/` via `.github/workflows/deploy-pages.yml`. Pages serves from a sub-path, which is why `vite.config.ts` sets `base: './'` — keep asset references relative or they break there while continuing to work on Vercel.
+Deployed to two places from `main`: **GitHub Pages at `naturalclar.github.io/slide-claude-code-lt/` is canonical** — it is what the OGP/Twitter tags in `index.html` point at — published by `.github/workflows/deploy-pages.yml`. Vercel at `claude-code-meetup-lt.vercel.app` still builds and serves the same deck, but is no longer the advertised URL.
+
+Pages serves from a sub-path, which is why `vite.config.ts` sets `base: './'` — keep asset references relative or they break there while continuing to work on Vercel. The OGP tags are the exception: they must stay **absolute** (`https://naturalclar.github.io/slide-claude-code-lt/...`), since crawlers do not resolve relative URLs. Vite leaves `meta content` untouched, so they are not rewritten by `base`.
 
 ## Commands
 
@@ -21,7 +23,7 @@ bun run deploy  # vercel --prod
 
 CI (`.github/workflows/ci.yml`) runs `check:pages`, `typecheck`, then `build` on pushes to `main` and on every PR. That is the whole safety net — there is no test suite and no linter. Note that `tsc` covers `Components.tsx`, `Themes.tsx` and `vite.config.ts` only: `slides.re.mdx` is typed through `slides.re.mdx.d.ts`, so slide markup itself is never type-checked, and Vite does not typecheck during `build`. Verify visual changes by loading the dev server and paging through the affected slides.
 
-`screenshot` runs `screenshot.mjs`, which drives Playwright against `http://localhost:5173` and writes `public/card.png` — where the OGP/Twitter meta tags in `index.html` resolve `/card.png` from. It exits with a clear message if nothing is serving `:5173`. Regenerate only on a machine with Japanese fonts installed: without them the `ゝ` in the title renders blank and the card silently degrades.
+`screenshot` runs `screenshot.mjs`, which drives Playwright against `http://localhost:5173` and writes `public/card.png` — the file the OGP/Twitter `og:image` URL points at, served as `/slide-claude-code-lt/card.png` on Pages. It exits with a clear message if nothing is serving `:5173`. Regenerate only on a machine with Japanese fonts installed: without them the `ゝ` in the title renders blank and the card silently degrades.
 
 ## Architecture
 

--- a/index.html
+++ b/index.html
@@ -15,11 +15,11 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:url"
-      content="https://claude-code-meetup-lt.vercel.app/"
+      content="https://naturalclar.github.io/slide-claude-code-lt/"
     />
     <meta
       property="og:image"
-      content="https://claude-code-meetup-lt.vercel.app/card.png"
+      content="https://naturalclar.github.io/slide-claude-code-lt/card.png"
     />
     <meta property="og:description" content="Claude Codeによる並列開発のすゝめ" />
     <meta property="og:site_name" content="Claude Codeによる並列開発のすゝめ" />
@@ -34,7 +34,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://claude-code-meetup-lt.vercel.app/card.png"
+      content="https://naturalclar.github.io/slide-claude-code-lt/card.png"
     />
   </head>
   <body>


### PR DESCRIPTION
Follow-up to #19. Makes Pages the canonical URL that shared links and social cards resolve to.

Three tags in `index.html` changed:

| tag | from | to |
| --- | --- | --- |
| `og:url` | `https://claude-code-meetup-lt.vercel.app/` | `https://naturalclar.github.io/slide-claude-code-lt/` |
| `og:image` | `…vercel.app/card.png` | `…github.io/slide-claude-code-lt/card.png` |
| `twitter:image` | `…vercel.app/card.png` | `…github.io/slide-claude-code-lt/card.png` |

No `vercel.app` references remain in `index.html`.

## These stay absolute on purpose

#19 moved everything else to relative paths via `base: './'`, so it is worth being explicit that OGP is the deliberate exception: **crawlers do not resolve relative URLs**, so `og:image` has to be fully qualified. Vite leaves `meta content` attributes untouched, so `base` would not have rewritten them in either direction.

That means these three URLs are now hard-coded to the Pages host and will not follow if the deck moves again — the one maintenance cost of this change. `CLAUDE.md` records why.

## Verification

Built and served the output under `/slide-claude-code-lt/`, the exact shape Pages uses:

- the three meta URLs survive the build unmodified (confirmed in `dist/index.html`)
- `card.png` is emitted to the build root, so the `og:image` path resolves: **`GET /slide-claude-code-lt/card.png` → 200, `image/png`, 326387 bytes**
- `check:pages` and `typecheck` pass

## Vercel

Left alone — it still builds and serves the same deck from `main`, and `bun run deploy` still works. It is simply no longer the advertised URL. Removing it entirely would mean dropping the `deploy` script and the Vercel project, which you have not asked for.

One thing I could not check from this sandbox: the network egress proxy blocks `naturalclar.github.io`, so I verified the sub-path behaviour against a local server rather than the live site. Worth pasting the Pages URL into a card validator once this merges, to confirm the image renders on the real host.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXXb5ytpQRFuFZqJHzucqH)_