### PR TITLE
Point the OGP tags at naturalclar.dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A single-deck RemdX (React + MDX) presentation: 「Claude Codeによる並列開発のすゝめ」, an LT given at Claude Code Meetup about parallel development with git worktree / git bare clone. Slide content and speaker notes are in Japanese.
 
-Deployed to two places from `main`: **GitHub Pages at `naturalclar.github.io/slide-claude-code-lt/` is canonical** — it is what the OGP/Twitter tags in `index.html` point at — published by `.github/workflows/deploy-pages.yml`. Vercel at `claude-code-meetup-lt.vercel.app` still builds and serves the same deck, but is no longer the advertised URL.
+Deployed to two places from `main`: **GitHub Pages, served at `naturalclar.dev/slide-claude-code-lt/`, is canonical** — it is what the OGP/Twitter tags in `index.html` point at — published by `.github/workflows/deploy-pages.yml`. Vercel at `claude-code-meetup-lt.vercel.app` still builds and serves the same deck, but is no longer the advertised URL.
 
-Pages serves from a sub-path, which is why `vite.config.ts` sets `base: './'` — keep asset references relative or they break there while continuing to work on Vercel. The OGP tags are the exception: they must stay **absolute** (`https://naturalclar.github.io/slide-claude-code-lt/...`), since crawlers do not resolve relative URLs. Vite leaves `meta content` untouched, so they are not rewritten by `base`.
+`naturalclar.dev` is a custom domain on the owner's *user* Pages site, so every project's Pages moves under it and this repo is reached at `naturalclar.dev/slide-claude-code-lt/`, not at `naturalclar.github.io/...`. The custom domain lives in Pages settings, not in this repo — there is no `CNAME` file here, and the deploy workflow does not need one.
+
+Pages serves from a sub-path, which is why `vite.config.ts` sets `base: './'` — keep asset references relative or they break there while continuing to work on Vercel. The OGP tags are the exception: they must stay **absolute** (`https://naturalclar.dev/slide-claude-code-lt/...`), since crawlers do not resolve relative URLs. Vite leaves `meta content` untouched, so they are not rewritten by `base`.
 
 ## Commands
 
@@ -23,7 +25,7 @@ bun run deploy  # vercel --prod
 
 CI (`.github/workflows/ci.yml`) runs `check:pages`, `typecheck`, then `build` on pushes to `main` and on every PR. That is the whole safety net — there is no test suite and no linter. Note that `tsc` covers `Components.tsx`, `Themes.tsx` and `vite.config.ts` only: `slides.re.mdx` is typed through `slides.re.mdx.d.ts`, so slide markup itself is never type-checked, and Vite does not typecheck during `build`. Verify visual changes by loading the dev server and paging through the affected slides.
 
-`screenshot` runs `screenshot.mjs`, which drives Playwright against `http://localhost:5173` and writes `public/card.png` — the file the OGP/Twitter `og:image` URL points at, served as `/slide-claude-code-lt/card.png` on Pages. It exits with a clear message if nothing is serving `:5173`. Regenerate only on a machine with Japanese fonts installed: without them the `ゝ` in the title renders blank and the card silently degrades.
+`screenshot` runs `screenshot.mjs`, which drives Playwright against `http://localhost:5173` and writes `public/card.png` — the file the OGP/Twitter `og:image` URL points at, served as `naturalclar.dev/slide-claude-code-lt/card.png`. It exits with a clear message if nothing is serving `:5173`. Regenerate only on a machine with Japanese fonts installed: without them the `ゝ` in the title renders blank and the card silently degrades.
 
 ## Architecture
 

--- a/index.html
+++ b/index.html
@@ -15,11 +15,11 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:url"
-      content="https://naturalclar.github.io/slide-claude-code-lt/"
+      content="https://naturalclar.dev/slide-claude-code-lt/"
     />
     <meta
       property="og:image"
-      content="https://naturalclar.github.io/slide-claude-code-lt/card.png"
+      content="https://naturalclar.dev/slide-claude-code-lt/card.png"
     />
     <meta property="og:description" content="Claude Codeによる並列開発のすゝめ" />
     <meta property="og:site_name" content="Claude Codeによる並列開発のすゝめ" />
@@ -34,7 +34,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://naturalclar.github.io/slide-claude-code-lt/card.png"
+      content="https://naturalclar.dev/slide-claude-code-lt/card.png"
     />
   </head>
   <body>


### PR DESCRIPTION
Corrects #20. I set the OGP URLs to `naturalclar.github.io/slide-claude-code-lt/`, but the site is actually served from **`naturalclar.dev/slide-claude-code-lt/`** — so the advertised URL and the real one did not match.

The reason: `naturalclar.dev` is a custom domain on the owner's *user* Pages site, and GitHub moves every project's Pages under it. I had assumed the default `<user>.github.io` host without checking, which I could not have caught from here anyway — the egress proxy blocks `github.io`, so my verification in #19 and #20 stopped at a local server standing in for Pages.

| tag | now |
| --- | --- |
| `og:url` | `https://naturalclar.dev/slide-claude-code-lt/` |
| `og:image` | `https://naturalclar.dev/slide-claude-code-lt/card.png` |
| `twitter:image` | `https://naturalclar.dev/slide-claude-code-lt/card.png` |

No `github.io` references remain in `index.html`.

## Verified against the live site this time

`naturalclar.dev` *is* reachable from this sandbox, so this is production, not a stand-in:

- `GET https://naturalclar.dev/slide-claude-code-lt/` → **200**
- every asset the deck references resolves → **all 11 images 200**, plus the emitted `assets/index-*.js` and `assets/index-*.css`
- `card.png` at the new `og:image` path → **200 `image/png`**

That incidentally confirms in production the relative-path work from #19, which until now had only been checked locally. The live HTML serves `./assets/…` and `./naturalclar.jpg`, and they resolve correctly under the sub-path on the custom domain.

One gap worth stating: I could not drive a browser against the live site — Playwright fails through the egress proxy — so this is HTTP-level verification plus the full 46-slide render check done locally in #19, not a live render.

## Also

No `CNAME` file is added. The custom domain is configured in Pages settings on the user site, so this repo does not need one and the deploy workflow is unchanged. `CLAUDE.md` now records that, so the next person does not "fix" the missing CNAME or reset the URLs to `github.io`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXXb5ytpQRFuFZqJHzucqH)_