### PR TITLE
Guard the styles.css overrides in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,9 @@ jobs:
       - run: bun run typecheck
 
       - run: bun run build
+
+      # check:styles drives a real browser over the built deck, so the browser
+      # has to be present. It runs after build because it serves dist/.
+      - run: bunx playwright install --with-deps chromium
+
+      - run: bun run check:styles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,12 @@ bun dev         # dev server on :5173 (npm run dev also works)
 bun run build   # vite build -> dist/
 bun run check:pages  # validate <Note>Page N</Note> markers against slide order
 bun run typecheck    # tsc --noEmit
+bun run check:styles # build first; asserts styles.css still matches RemdX's DOM
 bun run screenshot   # requires `bun dev` running first (see below)
 bun run deploy  # vercel --prod
 ```
 
-CI (`.github/workflows/ci.yml`) runs `check:pages`, `typecheck`, then `build` on pushes to `main` and on every PR. That is the whole safety net — there is no test suite and no linter. Note that `tsc` covers `Components.tsx`, `Themes.tsx` and `vite.config.ts` only: `slides.re.mdx` is typed through `slides.re.mdx.d.ts`, so slide markup itself is never type-checked, and Vite does not typecheck during `build`. Verify visual changes by loading the dev server and paging through the affected slides.
+CI (`.github/workflows/ci.yml`) runs `check:pages`, `typecheck`, `build`, then `check:styles` on pushes to `main` and on every PR. That is the whole safety net — there is no test suite and no linter. Note that `tsc` covers `Components.tsx`, `Themes.tsx` and `vite.config.ts` only: `slides.re.mdx` is typed through `slides.re.mdx.d.ts`, so slide markup itself is never type-checked, and Vite does not typecheck during `build`. Verify visual changes by loading the dev server and paging through the affected slides.
 
 `screenshot` runs `screenshot.mjs`, which drives Playwright against `http://localhost:5173` and writes `public/card.png` — the file the OGP/Twitter `og:image` URL points at, served as `naturalclar.dev/slide-claude-code-lt/card.png`. It exits with a clear message if nothing is serving `:5173`. Regenerate only on a machine with Japanese fonts installed: without them the `ゝ` in the title renders blank and the card silently degrades.
 
@@ -65,7 +66,9 @@ The render chain is small but entirely implicit; nothing imports anything the us
 
 - RemdX's automatic slide **scaling transform is disabled**. Content does not shrink to fit — a slide that overflows the fixed white card (`calc(100vh - 3rem)`, `overflow: hidden`) is silently clipped. This is why `Components.tsx` sizes things in `vh`/fixed px and why images are given explicit `width`/`height`.
 - The page paints a pink→yellow gradient background with a white card on top, forced globally. `Themes.tsx` only swaps the `--background-color`/`--text-color` CSS vars, so the `dark` theme is largely neutralized by these overrides.
-- Any `@nkzw/remdx` upgrade can change the emitted inline styles and break these selectors. Check every slide visually after bumping it. The 0.17 → 20 bump was checked this way and the selectors survived it, but that is luck, not a guarantee.
+- RemdX renders its containers with **inline styles and no classes or data attributes**, so there is nothing stabler to target — matching on style strings is the only option available, not a shortcut someone took.
+- Because of that, an `@nkzw/remdx` upgrade can stop these selectors matching and silently drop the white card, the gradient, or the scale override. `bun run check:styles` (`scripts/check-styles.mjs`) guards this in CI: it serves the real build, asserts every selector still matches, and asserts the result actually paints — 46 white cards, no surviving scale transform, gradient present. It fails with the specific override that broke.
+- The guard is not a substitute for looking: it proves the overrides still apply, not that the deck looks right. Still page through the slides after a bump.
 
 ## Dependency notes
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "vite build",
     "check:pages": "node ./scripts/check-page-numbers.mjs",
+    "check:styles": "node ./scripts/check-styles.mjs",
     "typecheck": "tsc --noEmit",
     "dev": "vite dev",
     "screenshot": "node ./screenshot.mjs",

--- a/scripts/check-styles.mjs
+++ b/scripts/check-styles.mjs
@@ -1,0 +1,114 @@
+// Guards the styles.css overrides against silent breakage.
+//
+// styles.css cannot target RemdX by class, because RemdX renders its
+// containers with inline styles and no classes or data attributes at all. The
+// overrides therefore match on inline style strings, e.g.
+// div[style*="transform: scale"]. If a RemdX upgrade changes the shape of
+// those strings, the selectors stop matching and the deck quietly loses its
+// white card, its gradient, or its disabled scaling -- with a green build.
+//
+// This serves the real build and asserts both that each selector still finds
+// something and that the resulting page actually looks the way it should.
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { extname, join, normalize } from "node:path";
+import { chromium } from "playwright";
+
+const DIST = "dist";
+const PORT = 4317;
+const SLIDES = 46;
+
+const TYPES = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".css": "text/css",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+};
+
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent(new URL(req.url, "http://x").pathname);
+  const file = join(DIST, normalize(path).replace(/^(\.\.[/\\])+/, ""));
+  const target = path.endsWith("/") ? join(file, "index.html") : file;
+  try {
+    await stat(target);
+    res.writeHead(200, { "content-type": TYPES[extname(target)] ?? "application/octet-stream" });
+    res.end(await readFile(target));
+  } catch {
+    res.writeHead(404).end();
+  }
+});
+
+// Each selector styles.css relies on, with what it must still match.
+const SELECTORS = [
+  { selector: '[style*="background-color: var(--background-color)"]', min: 1, styles: "the gradient background" },
+  { selector: 'div[style*="position: relative"][style*="z-index: 0"]', min: 1, styles: "the slide container" },
+  { selector: 'div[style*="position: relative"][style*="z-index: 0"] > *', min: 1, styles: "the white card" },
+  { selector: 'div[style*="transform: scale"]', min: 1, styles: "the disabled scale transform" },
+];
+
+const failures = [];
+
+await new Promise((resolve) => server.listen(PORT, resolve));
+const browser = await chromium.launch(
+  process.env.CHROMIUM_PATH ? { executablePath: process.env.CHROMIUM_PATH } : {},
+);
+try {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`http://localhost:${PORT}/`, { waitUntil: "networkidle" });
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(1500);
+
+  const counts = await page.evaluate(
+    (sels) => sels.map((s) => document.querySelectorAll(s).length),
+    SELECTORS.map(({ selector }) => selector),
+  );
+  SELECTORS.forEach(({ selector, min, styles }, index) => {
+    if (counts[index] < min) {
+      failures.push(`${selector}\n      matches ${counts[index]} elements, expected at least ${min} — ${styles} is no longer applied`);
+    }
+  });
+
+  // The selectors can still match while the result looks wrong, so check what
+  // actually got painted.
+  const painted = await page.evaluate(() => {
+    const cards = [...document.querySelectorAll("div")].filter((element) => {
+      const style = getComputedStyle(element);
+      return style.backgroundColor === "rgb(255, 255, 255)" && style.borderRadius !== "0px";
+    });
+    const scaled = [...document.querySelectorAll('div[style*="transform: scale"]')].filter(
+      (element) => getComputedStyle(element).transform !== "none",
+    );
+    return {
+      cards: cards.length,
+      scaled: scaled.length,
+      bodyBackground: getComputedStyle(document.body).backgroundImage,
+    };
+  });
+
+  if (painted.cards < SLIDES) {
+    failures.push(`only ${painted.cards} of ${SLIDES} slides render the white card`);
+  }
+  if (painted.scaled > 0) {
+    failures.push(`${painted.scaled} element(s) still carry a scale transform — content will not fit the fixed card`);
+  }
+  if (!painted.bodyBackground.includes("gradient")) {
+    failures.push(`body has no gradient background (got ${painted.bodyBackground})`);
+  }
+} finally {
+  await browser.close();
+  server.close();
+}
+
+if (failures.length > 0) {
+  console.error("styles.css no longer matches what RemdX renders:\n");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  console.error(
+    "\nRemdX likely changed its inline styles. Compare styles.css against the" +
+      "\nrendered DOM and update the selectors, then page through the deck.",
+  );
+  process.exit(1);
+}
+
+console.log(`styles.css OK: all selectors match, ${SLIDES} white cards, no scale transform, gradient present.`);


### PR DESCRIPTION
Fixes #15.

## The coupling cannot be removed — I checked

#15 floated replacing the inline-style matching with real class hooks "if upstream exposes any". **It does not.** I dumped the rendered DOM on remdx 20:

```
<div> style="background-color: black; height: 100vh; position: fixed; …"
  <div> style="height: 768.375px; overflow: hidden; position: relative; transform: scale(0.937042); …"
    <div> style="background: transparent; height: 100%; position: absolute; …"
```

Every RemdX container renders with **inline styles and no class or data attribute at all**. So `div[style*="transform: scale"]` is not a shortcut somebody took — it is the only handle that exists. That closes off the "fix the coupling" option and leaves the real problem, which is that breakage is *silent*: nothing fails, the build stays green, and you find out when the deck is on screen.

## So guard it instead

`scripts/check-styles.mjs`, wired into CI after `build`. It serves the real build and checks two different things:

1. **every fragile selector still matches something** — the gradient, the slide container, the white card, the scale override
2. **the page actually paints correctly** — 46 white cards, no element still carrying a scale transform, a gradient on `body`

Both halves matter: a selector can keep matching while the result is wrong, and the computed-style check catches that.

## It actually catches breakage

A guard that only ever passes is worthless, so I broke things deliberately:

| simulated breakage | result |
| --- | --- |
| scale selector renamed so it stops matching | ❌ `1 element(s) still carry a scale transform — content will not fit the fixed card` |
| container selector renamed | ❌ `only 0 of 46 slides render the white card` |
| unmodified tree | ✅ passes |

Both failures exit 1 and name the override that broke.

**One of those attempts is worth reporting because it initially "passed" when I expected a failure.** I had renamed only `div[style*="transform: scale"]`, and the check went green — correctly, as it turned out: the second, more specific rule at the bottom of `styles.css` still applied `transform: none`, so the page was genuinely fine. The guard was right and my test was wrong. Incidentally that means those two rules overlap, and the first is partly redundant — I left both alone rather than widen this PR.

## Findings I did not act on

- **`pre div.code-container` matches 0 elements.** Shiki 4 no longer emits that class, so the rule is dead. I left it: unlike the inline-style selectors it is a stable class selector, harmless, and would resume working correctly if the class returns. Flagging it rather than quietly deleting it.
- **`--sc-background-color` and `--sc-inline-code-background-color` in `:root` are load-bearing** — RemdX's own stylesheet consumes them, so they are not leftovers despite looking like it.

## Cost and limits

CI gains a `playwright install chromium` step, so the run is roughly a minute slower. Locally, `CHROMIUM_PATH` overrides the browser when the preinstalled build does not match the playwright version.

The guard proves the overrides still apply — **not that the deck looks right**. Paging through the slides after a remdx bump is still the real check, and `CLAUDE.md` says so.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXXb5ytpQRFuFZqJHzucqH)_